### PR TITLE
Bump to 0.19.17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.19.16" %}
+{% set version = "0.19.17" %}
 
 package:
   name: octave_kernel
@@ -7,7 +7,7 @@ package:
 source:
   fn: octave_kernel-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/o/octave_kernel/octave_kernel-{{ version }}.tar.gz
-  sha256: 98cec0c9bc35fac1153645a6b10fd8bbf5ca3ac6746c1e13ffb164eff6549743
+  sha256: e2b1e821a7c86c091cfe97e1af4c4fd7cf27a1c3b37d56a1e618eccb48716493
 
 build:
     number: 0
@@ -17,13 +17,13 @@ requirements:
   build:
     - python
     - setuptools
-    - metakernel >=0.17.2
+    - metakernel >=0.17.4
     - jupyter_client >=4.3
     - ipykernel
 
   run:
     - python
-    - metakernel >=0.17.2
+    - metakernel >=0.17.4
     - jupyter_client >=4.3
     - ipykernel
 


### PR DESCRIPTION
This depends on https://github.com/conda-forge/metakernel-feedstock/pull/15 finishing.